### PR TITLE
Annotaded ActionServiceImpl with @Transactional.

### DIFF
--- a/src/main/java/ch/zhaw/psit4/services/implementation/ActionServiceImpl.java
+++ b/src/main/java/ch/zhaw/psit4/services/implementation/ActionServiceImpl.java
@@ -10,6 +10,7 @@ import ch.zhaw.psit4.services.implementation.adapters.DialAdapter;
 import ch.zhaw.psit4.services.implementation.adapters.SayAlphaAdapter;
 import ch.zhaw.psit4.services.interfaces.ActionServiceInterface;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,6 +21,7 @@ import java.util.List;
  * @author Jona Braun
  */
 @Service
+@Transactional
 public class ActionServiceImpl implements ActionServiceInterface {
 
     private final DialRepository dialRepository;


### PR DESCRIPTION
Hope this gets rid of

2017-04-24T08:17:18.473261+00:00 app[web.1]: Caused by: javax.persistence.TransactionRequiredException: No EntityManager with actual transaction available for current thread - cannot reliably process 'remove' call
2017-04-24T08:17:18.473262+00:00 app[web.1]:    at org.springframework.orm.jpa.SharedEntityManagerCreator$SharedEntityManagerInvocationHandler.invoke(SharedEntityManagerCreator.java:282) ~[spring-orm-4.3.6.RELEASE.jar!/:4.3.6.RELEASE]
2017-04-24T08:17:18.473263+00:00 app[web.1]:    at com.sun.proxy.$Proxy82.remove(Unknown Source) ~[na:na]
2017-04-24T08:17:18.473263+00:00 app[web.1]:    at org.springframework.data.jpa.repository.query.JpaQueryExecution$DeleteExecution.doExecute(JpaQueryExecution.java:274) ~[spring-data-jpa-1.11.0.RELEASE.jar!/:na]
2017-04-24T08:17:18.473264+00:00 app[web.1]:    at org.springframework.data.jpa.repository.query.JpaQueryExecution.execute(JpaQueryExecution.java:85) ~[spring-data-jpa-1.11.0.RELEASE.jar!/:na]
2017-04-24T08:17:18.473264+00:00 app[web.1]:    at org.springframework.data.jpa.repository.query.AbstractJpaQuery.doExecute(AbstractJpaQuery.java:116) ~[spring-data-jpa-1.11.0.RELEASE.jar!/:na]
2017-04-24T08:17:18.473277+00:00 app[web.1]:    at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:96) ~[spring-tx-4.3.6.RELEASE.jar!/:4.3.6.RELEASE]
2017-04-24T08:17:18.473265+00:00 app[web.1]:    at org.springframework.data.jpa.repository.query.AbstractJpaQuery.execute(AbstractJpaQuery.java:106) ~[spring-data-jpa-1.11.0.RELEASE.jar!/:na]
2017-04-24T08:17:18.473266+00:00 app[web.1]:    at org.springframework.data.repository.core.support.RepositoryFactorySupport$QueryExecutorMethodInterceptor.doInvoke(RepositoryFactorySupport.java:483) ~[spring-data-commons-1.13.0.RELEASE.jar!/:na]
2017-04-24T08:17:18.473267+00:00 app[web.1]:    at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179) ~[spring-aop-4.3.6.RELEASE.jar!/:4.3.6.RELEASE]
2017-04-24T08:17:18.473277+00:00 app[web.1]:    at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179) ~[spring-aop-4.3.6.RELEASE.jar!/:4.3.6.RELEASE]
2017-04-24T08:17:18.473268+00:00 app[web.1]:    at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179) ~[spring-aop-4.3.6.RELEASE.jar!/:4.3.6.RELEASE]
2017-04-24T08:17:18.473275+00:00 app[web.1]:    at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:99) ~[spring-tx-4.3.6.RELEASE.jar!/:4.3.6.RELEASE]
2017-04-24T08:17:18.473266+00:00 app[web.1]:    at org.springframework.data.repository.core.support.RepositoryFactorySupport$QueryExecutorMethodInterceptor.invoke(RepositoryFactorySupport.java:461) ~[spring-data-commons-1.13.0.RELEASE.jar!/:na]
2017-04-24T08:17:18.473278+00:00 app[web.1]:    at org.springframework.dao.support.PersistenceExceptionTranslationInterceptor.invoke(PersistenceExceptionTranslationInterceptor.java:136) ~[spring-tx-4.3.6.RELEASE.jar!/:4.3.6.RELEASE]
2017-04-24T08:17:18.473267+00:00 app[web.1]:    at org.springframework.data.projection.DefaultMethodInvokingMethodInterceptor.invoke(DefaultMethodInvokingMethodInterceptor.java:61) ~[spring-data-commons-1.13.0.RELEASE.jar!/:na]
2017-04-24T08:17:18.473279+00:00 app[web.1]:    ... 88 common frames omitted
2017-04-24T08:17:18.473276+00:00 app[web.1]:    at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:282) ~[spring-tx-4.3.6.RELEASE.jar!/:4.3.6.RELEASE]